### PR TITLE
Max request response

### DIFF
--- a/main.c
+++ b/main.c
@@ -13,8 +13,7 @@
 
 #define PORT 0x39d8
 #define TTL 600
-#define MAX_REQ 271
-#define MAX_RES 300
+#define RECV_SIZE 512
 
 #define INADDR_LOOPBACK_INIT { 0x0100007f }
 
@@ -113,13 +112,13 @@ int main(int argc, char **argv)
 	}
 	sigaction(SIGTERM, &sa, NULL);
 
-	char msg[MAX_RES];
+	char msg[RECV_SIZE + 30];
 	struct sockaddr caddr;
 	socklen_t len = sizeof(caddr);
 	int flags = 0;
 
 	while (quit == 0) {
-		int n = recvfrom(sd, msg, MAX_REQ, flags, &caddr, &len);
+		int n = recvfrom(sd, msg, RECV_SIZE, flags, &caddr, &len);
 
 		if (n < 1) {
 			continue;

--- a/main.c
+++ b/main.c
@@ -13,7 +13,8 @@
 
 #define PORT 0x39d8
 #define TTL 600
-#define MSG_SIZE 512
+#define MAX_REQ 271
+#define MAX_RES 300
 
 #define INADDR_LOOPBACK_INIT { 0x0100007f }
 
@@ -112,13 +113,13 @@ int main(int argc, char **argv)
 	}
 	sigaction(SIGTERM, &sa, NULL);
 
-	char msg[MSG_SIZE];
+	char msg[MAX_RES];
 	struct sockaddr caddr;
 	socklen_t len = sizeof(caddr);
 	int flags = 0;
 
 	while (quit == 0) {
-		int n = recvfrom(sd, msg, MSG_SIZE, flags, &caddr, &len);
+		int n = recvfrom(sd, msg, MAX_REQ, flags, &caddr, &len);
 
 		if (n < 1) {
 			continue;

--- a/test/large-request.bats
+++ b/test/large-request.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  $BIN --port "$PORT" &
+  pid=$!
+}
+
+teardown() {
+  kill $pid
+  sleep 0
+}
+
+name="ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+@test "dig largest A record question" {
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+}
+
+@test "dig largest AAAA record question" {
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+}


### PR DESCRIPTION
An `AAAA` request for the longest legal domain name is 271 bytes. And a IPv6 response for the request is the original plus 28 bytes. So we'll never generate a response larger than 300 bytes.

Fixes #1.

/cc @scottjg