### PR TITLE
Parse EDNS0 request packets with OPT RR trailer

### DIFF
--- a/test/custom-port.bats
+++ b/test/custom-port.bats
@@ -16,7 +16,7 @@ teardown() {
 
 @test "dig A record" {
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	A	127.0.0.1"* ]]
@@ -24,7 +24,7 @@ teardown() {
 
 @test "dig AAAA record" {
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	AAAA	::1"* ]]

--- a/test/custom-records.bats
+++ b/test/custom-records.bats
@@ -17,7 +17,7 @@ teardown() {
 
 @test "dig custom A record" {
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	A	$A"* ]]
@@ -25,7 +25,7 @@ teardown() {
 
 @test "dig custom AAAA record" {
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	AAAA	$AAAA"* ]]

--- a/test/default-records.bats
+++ b/test/default-records.bats
@@ -14,7 +14,7 @@ teardown() {
 
 @test "dig default A record" {
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	A	127.0.0.1"* ]]
@@ -22,7 +22,7 @@ teardown() {
 
 @test "dig default AAAA record" {
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	AAAA	::1"* ]]

--- a/test/large-request.bats
+++ b/test/large-request.bats
@@ -14,14 +14,26 @@ teardown() {
 
 name="ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-@test "dig largest A record question" {
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+@test "dig largest A record question (plain DNS)" {
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noedns +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
 }
 
-@test "dig largest AAAA record question" {
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+@test "dig largest A record question (plain EDNS)" {
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+}
+
+@test "dig largest AAAA record question (plain DNS)" {
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+}
+
+@test "dig largest AAAA record question (plain EDNS)" {
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
 }

--- a/test/launchctl-ondemand-socket.bats
+++ b/test/launchctl-ondemand-socket.bats
@@ -22,7 +22,7 @@ teardown() {
   fi
 
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	A	127.0.0.1"* ]]
@@ -34,7 +34,7 @@ teardown() {
   fi
 
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	AAAA	::1"* ]]

--- a/test/launchctl-port.bats
+++ b/test/launchctl-port.bats
@@ -22,7 +22,7 @@ teardown() {
   fi
 
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	A	127.0.0.1"* ]]
@@ -34,7 +34,7 @@ teardown() {
   fi
 
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	AAAA	::1"* ]]

--- a/test/launchctl-socket.bats
+++ b/test/launchctl-socket.bats
@@ -22,7 +22,7 @@ teardown() {
   fi
 
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	A	127.0.0.1"* ]]
@@ -34,7 +34,7 @@ teardown() {
   fi
 
   name="test"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"test.			600	IN	AAAA	::1"* ]]

--- a/test/multiple-requests.bats
+++ b/test/multiple-requests.bats
@@ -12,21 +12,23 @@ teardown() {
   sleep 0
 }
 
-@test "dig multiple requests" {
+@test "dig multiple requests (plain DNS and plain EDNS)" {
   name="test"
 
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noedns +noall +answer +comments
   [ "$status" -eq 0 ]
 
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
 
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noedns +noall +answer +comments
   [ "$status" -eq 0 ]
 
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
 
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
 }

--- a/test/nxdomin.bats
+++ b/test/nxdomin.bats
@@ -14,42 +14,42 @@ teardown() {
 
 @test "dig MX record" {
   name="dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name MX +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name MX +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NXDOMAIN,"* ]]
 }
 
 @test "dig subdomain MX record" {
   name="foo.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name MX +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name MX +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NXDOMAIN,"* ]]
 }
 
 @test "dig CNAME record" {
   name="dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name CNAME +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name CNAME +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NXDOMAIN,"* ]]
 }
 
 @test "dig subdomain CNAME record" {
   name="foo.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name CNAME +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name CNAME +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NXDOMAIN,"* ]]
 }
 
 @test "dig TXT record" {
   name="dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name TXT +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name TXT +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NXDOMAIN,"* ]]
 }
 
 @test "dig subdomain TXT record" {
   name="foo.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name TXT +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name TXT +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NXDOMAIN,"* ]]
 }

--- a/test/plain-dns.bats
+++ b/test/plain-dns.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  $BIN --port="$PORT" &
+  pid=$!
+}
+
+teardown() {
+  kill -9 $pid
+  sleep 0
+}
+
+# subdomain tests
+
+@test "dig foo.dev A record (plain DNS)" {
+  name="foo.dev"
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+  [[ "$output" == *"foo.dev.		600	IN	A	127.0.0.1"* ]]
+}
+
+@test "dig foo.bar.dev A record (plain DNS)" {
+  name="foo.bar.dev"
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+  [[ "$output" == *"foo.bar.dev.		600	IN	A	127.0.0.1"* ]]
+}
+
+@test "dig foo.dev AAAA record (plain DNS)" {
+  name="foo.dev"
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NOERROR,"* ]]
+  [[ "$output" == *"foo.dev.		600	IN	AAAA	::1"* ]]
+}
+
+# NXDOMAIN tests
+
+@test "dig MX record (plain DNS)" {
+  name="dev"
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name MX +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NXDOMAIN,"* ]]
+}
+
+@test "dig subdomain MX record (plain DNS)" {
+  name="foo.dev"
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name MX +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NXDOMAIN,"* ]]
+}
+
+@test "dig subdomain CNAME record (plain DNS)" {
+  name="foo.dev"
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name CNAME +noedns +noall +answer +comments
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status: NXDOMAIN,"* ]]
+}

--- a/test/subdomains.bats
+++ b/test/subdomains.bats
@@ -14,7 +14,7 @@ teardown() {
 
 @test "dig dev A record" {
   name="dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"dev.			600	IN	A	127.0.0.1"* ]]
@@ -22,7 +22,7 @@ teardown() {
 
 @test "dig foo.dev A record" {
   name="foo.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"foo.dev.		600	IN	A	127.0.0.1"* ]]
@@ -30,7 +30,7 @@ teardown() {
 
 @test "dig bar.dev A record" {
   name="bar.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"bar.dev.		600	IN	A	127.0.0.1"* ]]
@@ -38,7 +38,7 @@ teardown() {
 
 @test "dig foo.bar.dev A record" {
   name="foo.bar.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name A +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"foo.bar.dev.		600	IN	A	127.0.0.1"* ]]
@@ -46,7 +46,7 @@ teardown() {
 
 @test "dig dev AAAA record" {
   name="dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"dev.			600	IN	AAAA	::1"* ]]
@@ -54,7 +54,7 @@ teardown() {
 
 @test "dig foo.dev AAAA record" {
   name="foo.dev"
-  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +noall +answer +comments
+  run dig +tries=1 +time=1 -p $PORT @127.0.0.1 $name AAAA +edns=0 +noall +answer +comments
   [ "$status" -eq 0 ]
   [[ "$output" == *"status: NOERROR,"* ]]
   [[ "$output" == *"foo.dev.		600	IN	AAAA	::1"* ]]


### PR DESCRIPTION
Modern versions of BIND 9 dig send requests with a trailing EDNS0-compliant ([RFC 6891](https://tools.ietf.org/html/rfc6891)) pseudo-RR record, which trips up the current approach to finding the QTYPE and QCLASS fields by looking at the last 4 bytes of the request packet.

Because of this, running `dig foo.localhost` now typically results in a failure (an NXDOMAIN reply), and the current test suite mostly fails, reflecting this fact.

While we could fix the test suite by just adding `+noedns` to all the dig queries, that would still leave the naive user, as well as various programs, receiving failure responses in the average use case.

Therefore we parse more of the request header fields and specifically read forward through the QNAME field to find QTYPE and QCLASS.

We check whether the QDCOUNT field is at least 1 before replying.

We also introduce some basic bounds checks so we don't read past the end of the received data (even though this would be safe, given the size of our buffer), and, more importantly, avoid reading backwards past the start of our buffer, which was previously possible if one sent a packet of only a few bytes, e.g., with `echo -n 1 | nc -4u -w0 127.0.0.1 55353`.

Note that this is by no means is this a full-fledged or complete implementation of EDNS, with all the bells and whistles that would require.  These changes merely attempt to allow launchdns to respond to queries which contain data beyond the QNAME withthout always sending NXDOMAIN, as happens now.

This should permit launchdns to function as an older DNS responder which simply ignores unknown OPT-type RRs in queries, so that a basic `dig foo.localhost` succeeds again.

The existing tests in the test suite now mostly use an explicit `+edns=0` option, just to clarify that this is the default dig behaviour.

In addition, some tests are repeated or mixed with dig invocations using the `+noedns` option to ensure test coverage of plain DNS requests as well.

---

In addition to the above, we do a small amount of formatting cleanup, bump the version number to 1.0.4, and, notably, resolve some flakiness in the CI tests.

The `timeout.bats` test would fail intermittently on Linux, in particular, because the `sa` `sigaction` struct was not initialized (cleared to zeros), so the `sa.sa_flags` field might sometimes happen to have its `SA_RESTART` flag set (along with other random flags, of course).

When the `SA_RESTART` flag was set, and the `SIGALRM` signal was received (i.e., when any timeout value specified on the command line with `-t`, such as in the `timeout.bats` test) while the `recvfrom()` call was blocking, the `recvfrom()` call would be automatically restarted instead of returning with `errno` set to `EINTR`, thus preventing the main loop from exiting upon the receipt of the timeout alarm.